### PR TITLE
V0.16.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/tf-keras-feedstock/pr2/1e84643

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/tf-keras-feedstock/pr2/7e69994

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/tf-keras-feedstock/pr2/1e84643
+  - https://staging.continuum.io/prefect/fs/tf-keras-feedstock/pr2/7e69994

--- a/recipe/LICENSE
+++ b/recipe/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-WHEEL_DIR=${PWD}/wheel_dir
-mkdir -p ${WHEEL_DIR}
-bazel build tensorflow_hub/pip_package:build_pip_package
-bazel-bin/tensorflow_hub/pip_package/build_pip_package ${WHEEL_DIR}
-pip install --no-deps --no-build-isolation ${WHEEL_DIR}/*.whl

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,4 +4,4 @@ WHEEL_DIR=${PWD}/wheel_dir
 mkdir -p ${WHEEL_DIR}
 bazel build tensorflow_hub/pip_package:build_pip_package
 bazel-bin/tensorflow_hub/pip_package/build_pip_package ${WHEEL_DIR}
-pip install --no-deps ${WHEEL_DIR}/*.whl
+pip install --no-deps --no-build-isolation ${WHEEL_DIR}/*.whl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,9 +11,8 @@ source:
 build:
   number: 0
     # tf-keras is not available for osx-arm64 because of a failed import error.
-    # tf-keras also not available for windows because of missing tf>2.10
     # no tensorflow for python 3.13
-  skip: true  # [py<39 or py>=313 or (osx and x86_64) or win]
+  skip: true  # [py<39 or py>=313 or (osx and x86_64)]
   ignore_run_exports:
     - libgcc-ng
     - libstdcxx-ng

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,14 +19,11 @@ build:
   script: {{ PYTHON }} -m pip install -vv --no-deps --no-build-isolation tensorflow_hub-{{ version }}-py2.py3-none-any.whl
 
 requirements:
-  build:
+  host:
     - python
     - pip
     - setuptools
     - wheel
-  host:
-    - python
-    - pip
   run:
     - python
     - numpy >=1.12.0
@@ -37,6 +34,10 @@ requirements:
 test:
   imports:
     - tensorflow_hub
+  commands:
+    - pip check
+  requires:
+    - pip
 
 about:
   home: https://www.tensorflow.org/hub/
@@ -44,7 +45,14 @@ about:
   dev_url: https://github.com/tensorflow/hub
   license: Apache-2.0
   license_family: Apache
+  license_file: tensorflow_hub/LICENSE
   summary: A library for transfer learning by reusing parts of TensorFlow models.
+  description: |
+    TensorFlow Hub is a library for transfer learning by reusing parts of
+    TensorFlow models.
+    It provides a collection of pre-trained models that can be used for
+    transfer learning.
+    It also provides a library for building and training models.
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.8.0" %}
+{% set version = "0.16.1" %}
 
 package:
   name: tensorflow-hub
@@ -6,15 +6,14 @@ package:
 
 source:
   url: https://github.com/tensorflow/hub/archive/v{{ version }}.tar.gz
-  sha256: 8b8d7b121855d43c52af4899552f1458ecd83bc9e50748dc4180e62e1d2bedd9
+  sha256: ce6abd3f1d39d42333b07c608ae022ac09a3f5984b297b21436c3389d7b77af5
 
 build:
   number: 0
   # This is a noarch: python package, it contains no compiled code but a
   # compiler is required to convert protocol buffer definitions.
   # The build has only been tested on linux-64
-  noarch: python
-  skip: true  # [not linux]
+  skip: true  # [py<39 and py>=313 or (osx and x86_64)]
   ignore_run_exports:
     - libgcc-ng
     - libstdcxx-ng
@@ -30,8 +29,10 @@ requirements:
   run:
     - python
     - numpy >=1.12.0
-    - six >=1.12.0
-    - protobuf >=3.8.0
+    - protobuf >=3.19.6
+    # tf-keras is not available for osx-arm64 because of a failed import error.
+    # see tf-keras feedstock
+    - tf-keras >=2.14.1  # [not (osx and x86_64)]
     - tensorflow >=1.14.0
 
 test:
@@ -40,8 +41,11 @@ test:
 
 about:
   home: https://www.tensorflow.org/hub/
+  doc_url: https://www.tensorflow.org/hub/
+  dev_url: https://github.com/tensorflow/hub
   license: Apache-2.0
-  license_file: LICENSE
+  license_family: Apache
+  license_file: tensorflow_hub/LICENSE
   summary: A library for transfer learning by reusing parts of TensorFlow models.
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,9 @@ source:
 build:
   number: 0
     # tf-keras is not available for osx-arm64 because of a failed import error.
+    # tf-keras also not available for windows because of missing tf>2.10
     # see tf-keras feedstock
-  skip: true  # [py<39 or py>=313 or (osx and x86_64)]
+  skip: true  # [py<39 or py>=313 or (osx and x86_64) or win]
   ignore_run_exports:
     - libgcc-ng
     - libstdcxx-ng
@@ -29,7 +30,9 @@ requirements:
     - numpy >=1.12.0
     - protobuf >=3.19.6
     - tf-keras >=2.14.1
-    - tensorflow >=1.14.0
+    - tensorflow >=1.15.0
+  run_constrained:
+    - keras <3.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,8 @@ requirements:
     - numpy >=1.12.0
     - protobuf >=3.19.6
     - tf-keras >=2.14.1
+    # tensorflow is not listed in upstream setup.py to allow users to choose variants,
+    # but is required at runtime (imported in file_utils.py and checked in __init__.py)
     - tensorflow >=1.15.0
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,9 +34,12 @@ requirements:
 
 test:
   imports:
-    - tensorflow_hub
+    - tensorflow_hub  # [not (osx and arm64)]
   commands:
     - pip check
+    # On osx-arm64, keras 3.x tries to import torch during tensorflow_hub import
+    # Set KERAS_BACKEND to tensorflow to avoid multi-backend initialization
+    - KERAS_BACKEND=tensorflow python -c "import tensorflow_hub; print('tensorflow_hub imported successfully')"  # [osx and arm64]
   requires:
     - pip
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ build:
   number: 0
     # tf-keras is not available for osx-arm64 because of a failed import error.
     # tf-keras also not available for windows because of missing tf>2.10
-    # see tf-keras feedstock
+    # no tensorflow for python 3.13
   skip: true  # [py<39 or py>=313 or (osx and x86_64) or win]
   ignore_run_exports:
     - libgcc-ng
@@ -34,12 +34,12 @@ requirements:
 
 test:
   imports:
-    - tensorflow_hub  # [not (osx and arm64)]
+    - tensorflow_hub
   commands:
+    # override any potential keras config file on the builder
+    - set KERAS_BACKEND=tensorflow     # [win]
+    - export KERAS_BACKEND=tensorflow  # [not win]
     - pip check
-    # On osx-arm64, keras 3.x tries to import torch during tensorflow_hub import
-    # Set KERAS_BACKEND to tensorflow to avoid multi-backend initialization
-    - KERAS_BACKEND=tensorflow python -c "import tensorflow_hub; print('tensorflow_hub imported successfully')"  # [osx and arm64]
   requires:
     - pip
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,7 @@ about:
   dev_url: https://github.com/tensorflow/hub
   license: Apache-2.0
   license_family: Apache
-  license_file: tensorflow_hub/LICENSE
+  license_file: LICENSE
   summary: A library for transfer learning by reusing parts of TensorFlow models.
   description: |
     TensorFlow Hub is a library for transfer learning by reusing parts of

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,14 +31,16 @@ requirements:
     - tf-keras >=2.14.1
     - tensorflow >=1.15.0
 
-test:
-  imports:
-    - tensorflow_hub
-  commands:
-    # override any potential keras config file on the builder
-    - set KERAS_BACKEND=tensorflow     # [win]
-    - export KERAS_BACKEND=tensorflow  # [not win]
-    - pip check
+  test:
+    imports:
+     - tensorflow_hub  # [not (osx and arm64)]
+    commands:
+      # Skip pip check on Windows due to conda/pip metadata conflict:
+      # tf-keras conda package references pip tensorflow dependency but we have conda tensorflow
+      - pip check  # [not win]
+     # On osx-arm64, keras 3.x tries to import torch during tensorflow_hub import
+     # Set KERAS_BACKEND to tensorflow to avoid multi-backend initialization
+     - KERAS_BACKEND=tensorflow python -c "import tensorflow_hub; print('tensorflow_hub imported successfully')"  # [osx and arm64]
   requires:
     - pip
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,8 @@ source:
 
 build:
   number: 0
-    # tf-keras is not available for osx-arm64 because of a failed import error.
-    # no tensorflow for python 3.13
+  # tf-keras is not available for osx-arm64 because of a failed import error.
+  # no tensorflow for python 3.13
   skip: true  # [py<39 or py>=313 or (osx and x86_64)]
   ignore_run_exports:
     - libgcc-ng
@@ -31,16 +31,16 @@ requirements:
     - tf-keras >=2.14.1
     - tensorflow >=1.15.0
 
-  test:
-    imports:
-     - tensorflow_hub  # [not (osx and arm64)]
-    commands:
-      # Skip pip check on Windows due to conda/pip metadata conflict:
-      # tf-keras conda package references pip tensorflow dependency but we have conda tensorflow
-      - pip check  # [not win]
-     # On osx-arm64, keras 3.x tries to import torch during tensorflow_hub import
-     # Set KERAS_BACKEND to tensorflow to avoid multi-backend initialization
-     - KERAS_BACKEND=tensorflow python -c "import tensorflow_hub; print('tensorflow_hub imported successfully')"  # [osx and arm64]
+test:
+  imports:
+    - tensorflow_hub  # [not (osx and arm64)]
+  commands:
+    # Skip pip check on Windows due to conda/pip metadata conflict:
+    # tf-keras conda package references pip tensorflow dependency but we have conda tensorflow
+    - pip check  # [not win]
+    # On osx-arm64, keras 3.x tries to import torch during tensorflow_hub import
+    # Set KERAS_BACKEND to tensorflow to avoid multi-backend initialization
+    - KERAS_BACKEND=tensorflow python -c "import tensorflow_hub; print('tensorflow_hub imported successfully')"  # [osx and arm64]
   requires:
     - pip
 
@@ -57,7 +57,7 @@ about:
     TensorFlow models.
     It provides a collection of pre-trained models that can be used for
     transfer learning.
-    It also provides a library for building and training models.
+    It also provides a library for building and training tools.
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ build:
   number: 0
     # tf-keras is not available for osx-arm64 because of a failed import error.
     # see tf-keras feedstock
-  skip: true  # [py<39 and py>=313 or (osx and x86_64)]
+  skip: true  # [py<39 or py>=313 or (osx and x86_64)]
   ignore_run_exports:
     - libgcc-ng
     - libstdcxx-ng

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ build:
   # This is a noarch: python package, it contains no compiled code but a
   # compiler is required to convert protocol buffer definitions.
   # The build has only been tested on linux-64
-  skip: true  # [py<39 and py>=313 or (osx and x86_64)]
+  skip: true  # [py<39 and py>=313]
   ignore_run_exports:
     - libgcc-ng
     - libstdcxx-ng

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,8 +31,6 @@ requirements:
     - protobuf >=3.19.6
     - tf-keras >=2.14.1
     - tensorflow >=1.15.0
-  run_constrained:
-    - keras <3.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,10 +10,9 @@ source:
 
 build:
   number: 0
-  # This is a noarch: python package, it contains no compiled code but a
-  # compiler is required to convert protocol buffer definitions.
-  # The build has only been tested on linux-64
-  skip: true  # [py<39 and py>=313]
+    # tf-keras is not available for osx-arm64 because of a failed import error.
+    # see tf-keras feedstock
+  skip: true  # [py<39 and py>=313 or (osx and x86_64)]
   ignore_run_exports:
     - libgcc-ng
     - libstdcxx-ng
@@ -30,9 +29,7 @@ requirements:
     - python
     - numpy >=1.12.0
     - protobuf >=3.19.6
-    # tf-keras is not available for osx-arm64 because of a failed import error.
-    # see tf-keras feedstock
-    - tf-keras >=2.14.1  # [not (osx and x86_64)]
+    - tf-keras >=2.14.1
     - tensorflow >=1.14.0
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,8 +5,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/tensorflow/hub/archive/v{{ version }}.tar.gz
-  sha256: ce6abd3f1d39d42333b07c608ae022ac09a3f5984b297b21436c3389d7b77af5
+  url: https://pypi.org/packages/py2.py3/t/tensorflow-hub/tensorflow_hub-{{ version }}-py2.py3-none-any.whl
+  sha256: e10c184b3d08daeafada11ffea2dd46781725b6bef01fad1f74d6634ad05311f
 
 build:
   number: 0
@@ -16,12 +16,14 @@ build:
   ignore_run_exports:
     - libgcc-ng
     - libstdcxx-ng
+  script: {{ PYTHON }} -m pip install -vv --no-deps --no-build-isolation tensorflow_hub-{{ version }}-py2.py3-none-any.whl
 
 requirements:
   build:
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
-    - bazel >=0.24
+    - python
+    - pip
+    - setuptools
+    - wheel
   host:
     - python
     - pip
@@ -42,7 +44,6 @@ about:
   dev_url: https://github.com/tensorflow/hub
   license: Apache-2.0
   license_family: Apache
-  license_file: tensorflow_hub/LICENSE
   summary: A library for transfer learning by reusing parts of TensorFlow models.
 
 extra:


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-5982](https://anaconda.atlassian.net/browse/PKG-5982)
- [Upstream repository](https://github.com/tensorflow/hub/tree/v0.16.1)
- [Upstream changelog/diff](https://github.com/tensorflow/hub/releases)

### Explanation of changes:

- No bazel build ( see https://github.com/conda-forge/tensorflow-hub-feedstock/pull/26)
- Version update
- Test workaround on osx-arm64 (see recipe comment)
- Skip pip check on windows (see recipe comment)


[PKG-5982]: https://anaconda.atlassian.net/browse/PKG-5982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ